### PR TITLE
Add ttyUSB to serial device poll filePattern

### DIFF
--- a/chillhub-devices.js
+++ b/chillhub-devices.js
@@ -471,7 +471,7 @@ exports.init = function(receiverCallback, deviceListCallback, attachmentsRoot) {
 	   //var filePattern = /^tty.usbmodem[0-9]+$/;
 	   var filePattern = /^tty.usbmodem[0-9]+([a-z]+[0-9]+)*$/;
    } else {
-	   var filePattern = /^ttyACM[0-9]{1,2}$/;
+	   var filePattern = /^(ttyACM[0-9]{1,2}|ttyUSB[0-9]{1,2})$/;
    }
 	
 	//similar to announce()

--- a/set-device-uuid.js
+++ b/set-device-uuid.js
@@ -274,7 +274,7 @@ if (process.platform === 'darwin') {
    console.log("We are running on a Mac, look for tty.usbmodem devices.");
    var filePattern = /^tty.usbmodem[0-9]+$/;
 } else {
-   var filePattern = /^ttyACM[0-9]{1,2}$/;
+   var filePattern = /^(ttyACM[0-9]{1,2}|ttyUSB[0-9]{1,2})$/;
 }
 
 fs.readdir('/dev/', function(err, files) {


### PR DESCRIPTION
Some Arduino devices show up as ttyUSB, for instance the Arduino Nano I have sitting on my desk. This might be an artifact of how the FTDI device is configured or maybe a counterfeit FTDI chip. 

References to both are found in the [ArchLinux Arduino Wiki Page](https://wiki.archlinux.org/index.php/Arduino)
